### PR TITLE
feat: Add basic support for OpenCensus tracing (resolvers only)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/99designs/gqlgen v0.17.34
 	github.com/spf13/cobra v1.7.0
 	github.com/vektah/gqlparser/v2 v2.5.6
+	go.opencensus.io v0.24.0
 )
 
 require (
@@ -45,7 +46,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/uber/jaeger-client-go v2.25.0+incompatible // indirect
 	github.com/zemirco/memorystore v0.0.0-20160308183530-ecd57e5134f6 // indirect
-	go.opencensus.io v0.24.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/automaxprocs v1.5.1 // indirect
 	go.uber.org/multierr v1.6.0 // indirect

--- a/opencensus_tracing.go
+++ b/opencensus_tracing.go
@@ -1,0 +1,52 @@
+package graphql
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/99designs/gqlgen/graphql"
+	"go.opencensus.io/trace"
+)
+
+var _ graphql.HandlerExtension = &OpenCensusTracingExtension{}
+var _ graphql.ResponseInterceptor = &OpenCensusTracingExtension{}
+var _ graphql.FieldInterceptor = &OpenCensusTracingExtension{}
+var _ graphql.OperationInterceptor = &OpenCensusTracingExtension{}
+
+type OpenCensusTracingExtension struct{}
+
+func (o *OpenCensusTracingExtension) ExtensionName() string {
+	return "OpenCensusTracing"
+}
+
+func (o *OpenCensusTracingExtension) InterceptField(ctx context.Context, next graphql.Resolver) (res interface{}, err error) {
+	fieldContext := graphql.GetFieldContext(ctx)
+
+	// for now, we only trace resolvers
+	if !fieldContext.IsResolver {
+		return next(ctx)
+	}
+
+	spanName := fmt.Sprintf("graphql/resolver/%s", fieldContext.Field.Name)
+	if fieldContext.Object != "Query" && fieldContext.Object != "Mutation" {
+		// enrich information if the resolver is registered on a graphql subtype, e.g. resolver that resolves `sortedList` on type `Users_Result`
+		spanName = fmt.Sprintf("graphql/resolver/%s/%s", fieldContext.Object, fieldContext.Field.Name)
+	}
+
+	ctx, span := trace.StartSpan(ctx, spanName)
+	defer span.End()
+
+	return next(ctx)
+}
+
+func (o *OpenCensusTracingExtension) InterceptOperation(ctx context.Context, next graphql.OperationHandler) graphql.ResponseHandler {
+	return next(ctx)
+}
+
+func (o *OpenCensusTracingExtension) InterceptResponse(ctx context.Context, next graphql.ResponseHandler) *graphql.Response {
+	return next(ctx)
+}
+
+func (o *OpenCensusTracingExtension) Validate(_ graphql.ExecutableSchema) error {
+	return nil
+}


### PR DESCRIPTION
Add some spans whenever a GraphQL resolver is called, this gives needed context for requests that contain multiple queries/mutations:

![2023-07-10 at 17 33](https://github.com/i-love-flamingo/graphql/assets/3203968/78931aaf-825f-4b09-98f6-a062166c9dce)
