### PR TITLE
chore: migrate golangci-lint to v2

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,6 +22,6 @@ jobs:
         with:
           fetch-depth: '0'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.64
+          version: v2.1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,19 +1,11 @@
-# Options for analysis running.
+version: "2"
 run:
   concurrency: 4
-  timeout: 5m
-  tests: true
   modules-download-mode: readonly
+  tests: true
   allow-parallel-runners: false
-
-# output configuration options
-output:
-  print-issued-lines: true
-  print-linter-name: true
-  sort-results: true
-
 linters:
-  disable-all: true
+  default: none
   enable:
     - bidichk
     - bodyclose
@@ -22,6 +14,7 @@ linters:
     - copyloopvar
     - cyclop
     - durationcheck
+    - err113
     - errcheck
     - errname
     - errorlint
@@ -31,17 +24,14 @@ linters:
     - gocognit
     - goconst
     - gocritic
-    - err113
-    - gofmt
-    - mnd
     - gomoddirectives
     - gosec
-    - gosimple
     - govet
     - grouper
     - ineffassign
     - makezero
     - misspell
+    - mnd
     - nakedret
     - nestif
     - nilerr
@@ -57,7 +47,6 @@ linters:
     - testpackage
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
     - unused
@@ -66,40 +55,58 @@ linters:
     - varnamelen
     - wrapcheck
     - wsl
-
+  settings:
+    mnd:
+      ignored-functions:
+        - context.WithTimeout
+    nolintlint:
+      require-explanation: true
+      require-specific: true
+    revive:
+      rules:
+        - name: var-naming
+          disabled: true
+    varnamelen:
+      max-distance: 10
+      ignore-names:
+        - err
+        - id
+        - to
+      ignore-type-assert-ok: true
+      ignore-map-index-ok: true
+      ignore-chan-recv-ok: true
+      ignore-decls:
+        - i int
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - containedctx
+          - err113
+          - forcetypeassert
+          - goconst
+          - varnamelen
+          - wrapcheck
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
+  uniq-by-line: true
   new: false
   fix: false
-  uniq-by-line: true
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - containedctx
-        - forcetypeassert
-        - goconst
-        - err113
-        - varnamelen
-        - wrapcheck
-
-linters-settings:
-  mnd:
-    ignored-functions:
-      - context.WithTimeout
-  nolintlint:
-    require-specific: true
-    require-explanation: true
-  revive:
-    rules:
-      - name: var-naming
-        disabled: true
-  varnamelen:
-    max-distance: 10
-    ignore-type-assert-ok: true
-    ignore-map-index-ok: true
-    ignore-chan-recv-ok: true
-    ignore-names:
-      - err
-      - id
-      - to
-    ignore-decls:
-      - i int
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
migrate golangci-lint to v2